### PR TITLE
Various improvements to infrastructure docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,7 @@ if desired. Access is managed by existing maintainers who can administer that ac
 Note that to upload videos or do other actions, you need to click on your profile in the top right of YouTube
 and "switch account" to the cert-manager brand account.
 
-### Zapier account
-
-> **Updated 30 June 2022:** Mael disabled zap (1) and (2). Both zaps are constantly failing
-> ([example email](https://groups.google.com/g/cert-manager-maintainers/c/-EfO3ar03vI)) with the
-> message "you have exceeded your quota". Zapier is on it.
-
-The zapier account has two zaps:
-
-1. _Upload new Google Drive videos that are copied into 'mael-zapier-upload-to-youtube' to the cert-manager YouTube channel_, and
-2. _Send a message on Slack (#cert-manager) when a new video is uploaded to the cert-manager Youtube channel_.
-
-As with other accounts, zapier credentials are currently stored in Jetstack password managers and will have to be moved to
-an open-source solution.
+Currently, videos from biweekly meetings are being manually uploaded to YouTube by maintainers.
 
 ### TestGrid
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ All infrastructure required by the cert-manager project. This includes:
 - infrastructure-as-code (Terraform)
 - details of services used by the project
 
+## Important Note: Credentials
+
+Currently, where this document states that credentials are stored in 1password, this means Venafi's private 1password org.
+
+This is for legacy reasons, but it is convenient since these credentials are currently mostly used by cert-manager maintainers who
+work at Venafi.
+
+It's the policy of the cert-manager project that these credentials should live in a place where they can be accessed by any maintainer,
+no matter where they work. In time, all credentials stored in Venafi's 1password org will be moved to an open-source friendly location.
+
 ## Services We Use
 
 As a project, cert-manager relies on several external services for different tasks. Some require
 access controls, which should ideally be open to any recognised cert-manager maintainer.
 
-Here, we list any services we know about and the method by which we change / configure / interact
-with those services.
+Here, we list any services we know about and the method by which we change / configure / interact with those services.
 
 ### Google Groups: cert-manager-maintainers
 
@@ -66,26 +75,23 @@ might need some adjustments since the Slack usernames are private to each Slack 
 
 We currently have two Netlify sites, both on different accounts.
 
-`cert-manager.netlify.app` is the main Netlify site and is tied to Jetstack's organizational account. The cert-manager maintainers at
-Jetstack can get access but this isn't available to open-source maintainers outside of Jetstack because the same org account is used
-for other Jetstack-internal sites.
+`cert-manager.netlify.app` is the main Netlify site and is tied to Jetstack's organizational account, owned by Venafi. The cert-manager maintainers at
+Venafi can get access but this isn't available to other maintainers because the same org account is used for some Jetstack-internal sites.
 
-We will migrate away from the Jetstack org when possible.
+We will migrate away from the old org when possible.
 
-The Jetstack account is used to publish the website on <https://cert-manager.io>. It also creates a preview site for PRs that are opened
+This account is used to publish the website on <https://cert-manager.io>. It also creates a preview site for PRs that are opened
 against the `master` branch; the preview link can be seen in the GitHub checks at the bottom of the PR UI. It is configured though
 through the Netlify console UI and also through the website repository (`_redirects` file).
 
 Our secondary account is `cert-manager-website.netlify.app`, which will be the destination for the site after it's moved away from the
-Jetstack org. This account's credentials are stored in Jetstack 1password and all Jetstack cert-manager maintainers have access to this
-account. Credentials will be moved into a more open-source-friendly location along with other credentials.
+old org. This account's credentials are stored in Venafi's 1password org.
 
 ### ArtifactHub
 
 We distribute our built helm charts [on ArtifactHub](https://artifacthub.io/packages/helm/cert-manager/cert-manager).
 
-Login details are currently stored in Jetstack 1password - it's a goal for us to store these details in a more open-source-friendly way
-down the road.
+Login details are stored in Venafi 1password.
 
 ### Algolia
 
@@ -128,7 +134,7 @@ There are also CNCF mailing lists, although we don't currently have an exhaustiv
 
 ### Social Media
 
-Credentials for all social media accounts are stored in Venafi's 1password and will be migrated to an open-source alternative in time.
+Credentials for all social media accounts are stored in Venafi's 1password.
 
 #### Twitter / X
 
@@ -151,11 +157,12 @@ Currently, videos from biweekly meetings are being manually uploaded to YouTube 
 
 ### TestGrid
 
-Testgrid is hosted [here](https://testgrid.k8s.io/jetstack-cert-manager-master) under the old org name.
-Configuration is updated with PRs like [this one](https://github.com/kubernetes/test-infra/pull/25229), which are generated
-by [this prow job](https://github.com/jetstack/testing/blob/b6fea2453d244c7803c59ad2b155e4c4c8ac021f/config/jobs/testing/testing-trusted.yaml#L63-L89).
+Testgrid is hosted [here](https://testgrid.k8s.io/cert-manager) with dashboards for all supported releases.
 
-There's also testgrid config in the [testing repo](https://github.com/jetstack/testing/blob/b6fea2453d244c7803c59ad2b155e4c4c8ac021f/config/testgrid/dashboards.yaml).
+Configuration is updated with PRs like [this one](https://github.com/kubernetes/test-infra/pull/25229), which are generated
+by [this prow job](https://github.com/cert-manager/testing/blob/b6fea2453d244c7803c59ad2b155e4c4c8ac021f/config/jobs/testing/testing-trusted.yaml#L63-L89).
+
+There's also testgrid config in the [testing repo](https://github.com/cert-manager/testing/blob/b6fea2453d244c7803c59ad2b155e4c4c8ac021f/config/testgrid/dashboards.yaml).
 
 ### Open Collective
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ in cert-manager development. It's a place for people to ask questions and get up
 
 Owners should be those in the `cert-manager-maintainers` group, but anyone is free to join the group.
 
+### Quay
+
+Currently, cert-manager container images are hosted on quay.io under the Jetstack organization which is controlled by Venafi. Admin
+credentials are available on Venafi's 1password.
+
+It's a goal of the cert-manager project to migrate images to be hosted under a `cert-manager` organization, but this introduces
+non-trivial operational challenges which we'd have to face to perform a migration.
+
+cert-manager container images are pushed to Quay via a robot account which is configured in Google Cloud Build.
+
+Other projects (e.g. trust-manager, csi-driver, etc) tend to be built locally and pushed using local credentials. It's a long-term
+ambition to change this in all instances.
+
 ### Slack
 
 We have 2 Slack channels on Kubernetes slack:

--- a/README.md
+++ b/README.md
@@ -126,12 +126,17 @@ This can be added to by existing maintainers, such as in [this PR](https://githu
 
 There are also CNCF mailing lists, although we don't currently have an exhaustive list of which ones are relevant.
 
-### `@CertManager` Twitter Account
+### Social Media
 
-This twitter account isn't currently used, but it exists and we have access to it if we want to start using it.
+Credentials for all social media accounts are stored in Venafi's 1password and will be migrated to an open-source alternative in time.
 
-As with other accounts, twitter credentials are currently stored in Jetstack password managers and will have to be moved to
-an open-source solution.
+#### Twitter / X
+
+[`@CertManager`](https://twitter.com/CertManager/) is used by maintainers to tweet about important releases or community updates.
+
+#### Mastodon / infosec.exchange
+
+[`@CertManager@infosec.exchange`](https://infosec.exchange/@CertManager) is used by maintainers to toot about important releases or community updates.
 
 ### cert-manager YouTube Account
 


### PR DESCRIPTION
Each commit is self-contained, here's a list of them:

1. Remove zapier section (it's outdated) and add details on YouTube upload process
2. Improve notes on our social media accounts
3. Clean up how we talk about 1password and our intent to migrate in the future
4. Add some docs on quay.io and how we handle container images