### PR TITLE
Add terraform definitions of our CNCF-hosted GCP infrastructure

### DIFF
--- a/gcp/general_tfstate_bucket.tf
+++ b/gcp/general_tfstate_bucket.tf
@@ -1,0 +1,10 @@
+resource "google_storage_bucket" "default" {
+  name                        = "cert-manager-terraform-state"
+  location                    = "EU"
+  project                     = module.cert-manager-general.project_id
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "gcs" {
+    bucket = "cert-manager-terraform-state"
+    prefix  = "terraform/state"
+  }
+
+  # backend "local" {
+  #  path = "terraform.tfstate"
+  # }
+
+  required_version = "= 1.6.1"
+}
+
+provider "google" {
+  region = local.gcp_region
+
+  default_labels = {
+    managed-by = "terraform"
+  }
+}

--- a/gcp/modules/gcp-project/main.tf
+++ b/gcp/modules/gcp-project/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.20.0"
+    }
+  }
+  required_version = "= 1.6.1"
+}
+
+resource "google_project" "project" {
+  name            = var.project_name
+  project_id      = var.project_id
+  folder_id       = var.project_folder_id
+  billing_account = var.project_billing_id
+
+  auto_create_network = false
+
+  lifecycle {
+    prevent_destroy = "true"
+  }
+}
+
+# Lien to prevent manual deletion https://cloud.google.com/resource-manager/docs/project-liens 
+resource "google_resource_manager_lien" "block_deletion" {
+  parent       = "projects/${google_project.project.number}"
+  restrictions = ["resourcemanager.projects.delete"]
+  origin       = "${var.project_id}-project-lien"
+  reason       = "This project is an important environment"
+}
+
+# Add all cert-manager release managers as 'owners' of the GCP project.
+resource "google_project_iam_member" "project_owners" {
+  for_each = var.project_owners
+  project  = google_project.project.project_id
+  role     = "roles/owner"
+  member   = each.value
+}
+
+# Enable all required APIs for the project.
+resource "google_project_service" "project_apis" {
+  for_each = var.project_apis
+  project  = google_project.project.project_id
+  service  = each.value
+
+  # If this service is disabled (i.e. the Terraform resource is destroyed),
+  # automatically disable any dependent project services.
+  disable_dependent_services = true
+}

--- a/gcp/modules/gcp-project/outputs.tf
+++ b/gcp/modules/gcp-project/outputs.tf
@@ -1,0 +1,6 @@
+output "project_id" {
+    value = google_project.project.project_id
+}
+output "number" {
+    value = google_project.project.number
+}

--- a/gcp/modules/gcp-project/variables.tf
+++ b/gcp/modules/gcp-project/variables.tf
@@ -1,0 +1,25 @@
+variable "project_name" {
+  description = "The name of the project to create"
+  type        = string
+}
+variable "project_id" {
+  description = "The project ID to use"
+  type        = string
+}
+variable "project_folder_id" {
+  description = "The folder to create the project under"
+  type        = string
+}
+variable "project_billing_id" {
+  description = "The billing account to associate with the project"
+  type        = string
+}
+variable "project_owners" {
+  type    = set(string)
+  default = []
+}
+
+variable "project_apis" {
+  type    = set(string)
+  default = []
+}

--- a/gcp/projects.tf
+++ b/gcp/projects.tf
@@ -1,0 +1,49 @@
+locals {
+  project_folder_id       = "585046353847"         # cert-manager folder
+  cncf_project_billing_id = "010256-CB82C2-8ED6FC" # "CNCF Invoiced Billing"
+}
+
+module "cert-manager-general" {
+  source = "./modules/gcp-project/"
+
+  project_name       = "CM generic project"
+  project_id         = "cert-manager-general"
+  project_folder_id  = local.project_folder_id
+  project_billing_id = local.cncf_project_billing_id
+  project_owners     = local.cert_manager_release_managers
+}
+
+module "cert-manager-release" {
+  source = "./modules/gcp-project/"
+
+  project_name       = "CM release infra"
+  project_id         = "cert-manager-release"
+  project_folder_id  = local.project_folder_id
+  project_billing_id = local.cncf_project_billing_id
+  project_owners     = local.cert_manager_release_managers
+  project_apis = toset([
+    "cloudbuild.googleapis.com",
+    "storage.googleapis.com",
+    "cloudkms.googleapis.com",
+  ])
+}
+
+module "cert-manager-tests-trusted" {
+  source = "./modules/gcp-project/"
+
+  project_name       = "CM testing infra - trusted"
+  project_id         = "cert-manager-tests-trusted"
+  project_folder_id  = local.project_folder_id
+  project_billing_id = local.cncf_project_billing_id
+  project_owners     = local.cert_manager_release_managers
+}
+
+module "cert-manager-tests-untrusted" {
+  source = "./modules/gcp-project/"
+
+  project_name       = "CM testing infra - untrusted"
+  project_id         = "cert-manager-tests-untrusted"
+  project_folder_id  = local.project_folder_id
+  project_billing_id = local.cncf_project_billing_id
+  project_owners     = local.cert_manager_release_managers
+}

--- a/gcp/release.tf
+++ b/gcp/release.tf
@@ -1,0 +1,155 @@
+locals {
+  // The service account used by Cloud Build (see https://console.cloud.google.com/cloud-build/settings/service-account?project=cert-manager-release).
+  cert_manager_release_gcb_service_account = format("serviceAccount:%s@cloudbuild.gserviceaccount.com", module.cert-manager-release.number)
+}
+
+resource "google_service_account" "scheduler_gcb_invoker" {
+  account_id   = "scheduler-gcb-invoker"
+  description  = "Allows cloud-scheduler to invoke GCB jobs"
+  display_name = "scheduler-gcb-invoker"
+  project      = module.cert-manager-release.project_id
+}
+
+resource "google_project_iam_binding" "cert-manager-release_managers" {
+  project = module.cert-manager-release.project_id
+  role    = "roles/cloudbuild.builds.builder"
+
+  members = setunion(
+    # Allow release managers access to all required APIs for interacting with
+    # the Cloud Build service.
+    # More information on this role can be found here:
+    # https://cloud.google.com/iam/docs/understanding-roles#cloud-build-roles
+    local.cert_manager_release_managers,
+    # We must explicitly grant the managed GCP service account IAM permission
+    # to launch jobs in the project because the 'iam_binding' type of Terraform
+    # resource is authorative for the role type.
+    [
+      local.cert_manager_release_gcb_service_account,
+      google_service_account.scheduler_gcb_invoker.member,
+    ],
+  )
+}
+
+#####
+## Define Cloud Storage bucket and related IAM permissions
+#####
+
+# The the GCS bucket that contains release artifacts
+resource "google_storage_bucket" "cert-manager-release" {
+  name     = "cert-manager-release"
+  location = "EU"
+
+  project = module.cert-manager-release.project_id
+}
+
+# Define list of users with objectViewer permission on the release bucket
+resource "google_storage_bucket_iam_binding" "cert-manager-release_object-viewers" {
+  bucket = google_storage_bucket.cert-manager-release.name
+  role   = "roles/storage.objectViewer"
+
+  # Allow release managers to view the release bucket objects
+  members = local.cert_manager_release_managers
+}
+
+# Define list of users with objectAdmin permission on the release bucket.
+resource "google_storage_bucket_iam_binding" "cert-manager-release_object-admins" {
+  bucket = google_storage_bucket.cert-manager-release.name
+  role   = "roles/storage.objectAdmin"
+
+  members = [
+    # Grant the GCB service account admin permissions on objects in the bucket.
+    # This grants full control of objects, including listing, creating,
+    # viewing, and deleting objects.
+    # objectCreator is not sufficient, as the tool may need to delete or
+    # overwrite existing files.
+    # More information on roles can be found here:
+    # https://cloud.google.com/iam/docs/understanding-roles#storage-roles
+    local.cert_manager_release_gcb_service_account,
+  ]
+}
+
+#####
+## Define Cloud KMS keyring and related IAM permissions
+#####
+
+# Create a KMS keyring to hold the key used to encrypt release secrets.
+resource "google_kms_key_ring" "cert-manager-release" {
+  name     = "cert-manager-release"
+  project  = module.cert-manager-release.project_id
+  location = "europe-west1"
+}
+
+# Create the actual key used to encrypt and decrypt secrets.
+resource "google_kms_crypto_key" "cert-manager-release_secret-key" {
+  name     = "cert-manager-release-secret-key"
+  key_ring = google_kms_key_ring.cert-manager-release.id
+  purpose  = "ENCRYPT_DECRYPT"
+
+  # Prevent destroying this key to avoid us losing access to encrypted data.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Define list of users with cryptoKeyEncrypter permissions on the release
+# secret key.
+resource "google_kms_crypto_key_iam_binding" "cert-manager-release_secret-key-encrypters" {
+  crypto_key_id = google_kms_crypto_key.cert-manager-release_secret-key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypter"
+
+  # Grant release managers permission to encrypt new secrets only.
+  # This only needs to happen when creating new secrets or rotating existing
+  # ones.
+  members = local.cert_manager_release_managers
+}
+
+# Define list of users with cryptoKeyDecrypter permissions on the release
+# secret key.
+resource "google_kms_crypto_key_iam_binding" "cert-manager-release_secret-key-decrypters" {
+  crypto_key_id = google_kms_crypto_key.cert-manager-release_secret-key.id
+  role          = "roles/cloudkms.cryptoKeyDecrypter"
+
+  # Grant the Cloud Build service account permission to decrypt secrets using
+  # the secret key.
+  members = [
+    local.cert_manager_release_gcb_service_account,
+  ]
+}
+
+# Key for signing cert-manager release artifacts
+resource "google_kms_crypto_key" "cert-manager-release_signing-key" {
+  name     = "cert-manager-release-signing-key"
+  key_ring = google_kms_key_ring.cert-manager-release.id
+  purpose  = "ASYMMETRIC_SIGN"
+
+  # Prevent destroying this key; end-users of cert-manager will use the public part of this key
+  # to verify signatures, meaning that while rotation is possible, it's a non-trivial task which will
+  # ideally be communicated to the community well in advance. Destroying the key is a big decision
+  # which shouldn't be taken lightly.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  version_template {
+    # PKCS1 v1.5 and SHA512 are both requirements of helm for signing charts, meaning
+    # that at the time of writing this is the only valid choice we have for the algorithm
+    algorithm = "RSA_SIGN_PKCS1_4096_SHA512"
+  }
+}
+
+# Define list of users who have permission to sign using this key.
+resource "google_kms_crypto_key_iam_binding" "cert-manager-release_signing-key-signers" {
+  crypto_key_id = google_kms_crypto_key.cert-manager-release_secret-key.id
+
+  # https://cloud.google.com/kms/docs/reference/permissions-and-roles
+  # "roles/cloudkms.signer" doesn't include permission to get the public key, which is required
+  # when we sign helm charts and when we bootstrap the key. We don't call "verify" anywhere,
+  # but signerVerifier is the closest role which includes both "signer" and "publicKeyViewer" and it's
+  # not a security concern to allow signers to verify; it's not worth making a custom role.
+  role = "roles/cloudkms.signerVerifier"
+
+  # Signing should be done only by cmrel in cloudbuild jobs
+  members = [
+    local.cert_manager_release_gcb_service_account,
+  ]
+}

--- a/gcp/release_gcb.tf
+++ b/gcp/release_gcb.tf
@@ -1,0 +1,42 @@
+resource "google_cloudbuild_trigger" "cert-manager-build-on-tag" {
+  description = "Builds cert-manager when a tag is pushed"
+
+  filename = "gcb/build_cert_manager.yaml"
+  location = "global"
+  name     = "cert-manager-build-on-tag"
+  project  = module.cert-manager-release.project_id
+
+  approval_config {
+    approval_required = false
+  }
+  github {
+    name  = "cert-manager"
+    owner = "cert-manager"
+    push {
+      tag = "^v.*$"
+    }
+  }
+}
+
+resource "google_cloudbuild_trigger" "cert-manager-package-debian" {
+  description = "Builds the debian-based trust package for trust-manager. Run regularly via a scheduled trigger"
+
+  location = "global"
+  name     = "cert-manager-package-debian"
+  project  = module.cert-manager-release.project_id
+
+  approval_config {
+    approval_required = false
+  }
+  git_file_source {
+    path      = "gcb/ci-update-debian-trust-package.yaml"
+    repo_type = "GITHUB"
+    revision  = "refs/heads/main"
+    uri       = "https://github.com/cert-manager/trust-manager"
+  }
+  source_to_build {
+    ref       = "refs/heads/main"
+    repo_type = "GITHUB"
+    uri       = "https://github.com/cert-manager/trust-manager"
+  }
+}

--- a/gcp/release_imported.tf
+++ b/gcp/release_imported.tf
@@ -1,0 +1,79 @@
+// Storage buckets
+
+resource "google_storage_bucket" "cert_manager_release_cloudbuild" {
+  name     = "cert-manager-release_cloudbuild"
+  location = "US"
+  project  = module.cert-manager-release.project_id
+}
+
+resource "google_storage_bucket" "cert_manager_release_backup_2022_03_30" {
+  name                        = "cert-manager-release-backup-2022-03-30"
+  location                    = "EU"
+  project                     = module.cert-manager-release.project_id
+  uniform_bucket_level_access = true
+}
+
+// Firewall rules
+
+resource "google_compute_firewall" "default_allow_icmp" {
+  allow {
+    protocol = "icmp"
+  }
+
+  description   = "Allow ICMP from anywhere"
+  direction     = "INGRESS"
+  name          = "default-allow-icmp"
+  network       = "https://www.googleapis.com/compute/v1/projects/cert-manager-release/global/networks/default"
+  priority      = 65534
+  project       = module.cert-manager-release.project_id
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "default_allow_internal" {
+  allow {
+    ports    = ["0-65535"]
+    protocol = "tcp"
+  }
+
+  allow {
+    ports    = ["0-65535"]
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  description   = "Allow internal traffic on the default network"
+  direction     = "INGRESS"
+  name          = "default-allow-internal"
+  network       = "https://www.googleapis.com/compute/v1/projects/cert-manager-release/global/networks/default"
+  priority      = 65534
+  project       = module.cert-manager-release.project_id
+  source_ranges = ["10.128.0.0/9"]
+}
+
+// Service accounts
+
+resource "google_service_account" "dns01_solver" {
+  account_id   = "dns01-solver"
+  display_name = "dns01-solver"
+  project      = module.cert-manager-release.project_id
+}
+
+resource "google_service_account" "give_me_my_cluster" {
+  account_id   = "give-me-my-cluster"
+  display_name = "For the give-me-my-cluster CLI"
+  project      = module.cert-manager-release.project_id
+}
+
+// IAM roles
+
+resource "google_project_iam_custom_role" "cloudkmskeyversiongetter" {
+  description = "Created on: 2021-10-13"
+  permissions = ["cloudkms.cryptoKeyVersions.get", "cloudkms.cryptoKeys.get"]
+  project     = module.cert-manager-release.project_id
+  role_id     = "CloudKMSKeyVersionGetter"
+  stage       = "GA"
+  title       = "Cloud KMS Key Version Getter"
+}

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -1,0 +1,11 @@
+locals {
+  # List of users that have permission to stage and publish builds
+  cert_manager_release_managers = toset([
+    "user:tim.ramlot@jetstack.io",
+    "user:mael.valais@jetstack.io",
+    "user:richard.wall@jetstack.io",
+    "user:ashley.davis@jetstack.io",
+  ])
+
+  gcp_region = "europe-west1"
+}


### PR DESCRIPTION
This PR adds the terraform definitions for our cert-manager projects hosted under the CNCF-organisation.
Currently, this consists of 4 projects "cert-manager-general", "cert-manager-release", "cert-manager-tests-trusted" and "cert-manager-tests-untrusted".
Only "cert-manager-general" and "cert-manager-release" are used currently.
- "cert-manager-general" contains the tfstate bucket used to store the terraform state for these definitions.
- "cert-manager-release" contains the definitions based on the old Jetstack terraform combined with imported resources that were missing from the Jetstack terraform files.

I used tofu to plan these resources (https://opentofu.org/).