### PR TITLE
Allow newer tofu versions

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,20 @@
 approvers:
 - munnerz
-- JoshVanL
+- joshvanl
+- wallrj
 - jakexks
-- irbekrm
 - maelvls
-- SgtCoDFish
+- irbekrm
+- sgtcodfish
+- inteon
+reviewers:
+- munnerz
+- joshvanl
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- inteon
+- thatsmrtalbot
+- erikgb

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -8,7 +8,7 @@ terraform {
   #  path = "terraform.tfstate"
   # }
 
-  required_version = "= 1.6.1"
+  required_version = ">= 1.6.1"
 }
 
 provider "google" {

--- a/gcp/modules/gcp-project/main.tf
+++ b/gcp/modules/gcp-project/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "5.20.0"
     }
   }
-  required_version = "= 1.6.1"
+  required_version = ">= 1.6.1"
 }
 
 resource "google_project" "project" {


### PR DESCRIPTION
Currently the GCP terraform _requires_ an exact version of OpenTofu, which doesn't allow for the use of newer versions. I've confirmed this works with 1.6.2.

Example of the error this fixes:

```text
│ Error: Unsupported OpenTofu Core version
│
│   on main.tf line 11, in terraform:
│   11:   required_version = "= 1.6.1"
│
│ This configuration does not support OpenTofu version 1.6.2. To proceed, either choose another supported OpenTofu version or update this version constraint. Version constraints are normally set for good reason, so updating the constraint may lead to other errors or unexpected behavior.
```