### PR TITLE
Switch to uniform_bucket_level_access for the release bucket

### DIFF
--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -15,8 +15,6 @@ module "release-bucket" {
   location    = local.bucket_location
   bucket_name = "cert-manager-release"
 
-  uniform_bucket_level_access = false
-
   bucket_viewers = local.cert_manager_release_managers
   bucket_admins = [
     # Grant the GCB service account admin permissions on objects in the bucket.

--- a/gcp/modules/gcp-bucket/main.tf
+++ b/gcp/modules/gcp-bucket/main.tf
@@ -14,7 +14,7 @@ resource "google_storage_bucket" "bucket" {
   location = var.location
   project  = var.project_id
 
-  uniform_bucket_level_access = var.uniform_bucket_level_access
+  uniform_bucket_level_access = true
   public_access_prevention    = var.bucket_prevent_public_access ? "enforced" : "inherited"
 
   versioning {

--- a/gcp/modules/gcp-bucket/variables.tf
+++ b/gcp/modules/gcp-bucket/variables.tf
@@ -29,10 +29,3 @@ variable "bucket_admins" {
   type    = set(string)
   default = []
 }
-
-# TODO: remove this once we resolve the rclone issues
-# see https://github.com/cert-manager/cert-manager/pull/6906
-variable "uniform_bucket_level_access" {
-  type    = bool
-  default = true
-}


### PR DESCRIPTION
Now that we have the following PRs merged, the release process should work with non-ACL buckets too:
- https://github.com/cert-manager/cert-manager/pull/6906
- https://github.com/cert-manager/cert-manager/pull/6946
- https://github.com/cert-manager/cert-manager/pull/6945
- https://github.com/cert-manager/cert-manager/pull/6942