### PR TITLE
Remove storage-transfer-service SA since testgrid has been migrated

### DIFF
--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -57,9 +57,6 @@ module "trusted-testgrid-bucket" {
     [
       "serviceAccount:testgrid-canary@k8s-testgrid.iam.gserviceaccount.com",
       "serviceAccount:updater@k8s-testgrid.iam.gserviceaccount.com",
-      # Temporary SA used for copy job, can be removed once we stop the job, which
-      # can be stopped once https://github.com/kubernetes/test-infra/pull/32455 is merged
-      "serviceAccount:project-771478705899@storage-transfer-service.iam.gserviceaccount.com",
     ],
   )
   bucket_admins = [


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/32455, we migrated testgrid to the new bucket.
This means we no longer need the storage transfer job and this SA can be removed.