### PR TITLE
Remove cert-manager-package-debian gcb job

### DIFF
--- a/gcp/release_gcb.tf
+++ b/gcp/release_gcb.tf
@@ -17,26 +17,3 @@ resource "google_cloudbuild_trigger" "cert-manager-build-on-tag" {
     }
   }
 }
-
-resource "google_cloudbuild_trigger" "cert-manager-package-debian" {
-  description = "Builds the debian-based trust package for trust-manager. Run regularly via a scheduled trigger"
-
-  location = "global"
-  name     = "cert-manager-package-debian"
-  project  = module.cert-manager-release.project_id
-
-  approval_config {
-    approval_required = false
-  }
-  git_file_source {
-    path      = "gcb/ci-update-debian-trust-package.yaml"
-    repo_type = "GITHUB"
-    revision  = "refs/heads/main"
-    uri       = "https://github.com/cert-manager/trust-manager"
-  }
-  source_to_build {
-    ref       = "refs/heads/main"
-    repo_type = "GITHUB"
-    uri       = "https://github.com/cert-manager/trust-manager"
-  }
-}


### PR DESCRIPTION
We migrated this build logic to run on GH actions, similar to the release of trust-manager itself (see https://github.com/cert-manager/trust-manager/pull/195).