### PR TITLE
Add triageparty infrastructure

### DIFF
--- a/gcp/clusters.tf
+++ b/gcp/clusters.tf
@@ -10,7 +10,7 @@ module "prow-cluster-trusted" {
   cluster_description = "Test cluster for trusted tests"
 
   cluster_enable_workload_identity = true
-  cluster_enable_http_load_balancing = true
+  cluster_enable_gateway_api = true
 
   node_config = {
     min_count = 0

--- a/gcp/general_dns_cert-manager.tf
+++ b/gcp/general_dns_cert-manager.tf
@@ -43,6 +43,16 @@ resource "google_dns_record_set" "a-prow-infra-cert-manager-io" {
   type         = "A"
 }
 
+resource "google_dns_record_set" "a-triage-infra-cert-manager-io" {
+  project      = module.cert-manager-general.project_id
+  managed_zone = google_dns_managed_zone.cert-manager-io.name
+
+  name         = "triage.infra.cert-manager.io."
+  rrdatas      = [google_compute_global_address.triage_loadbalancer_ip.address]
+  ttl          = 300
+  type         = "A"
+}
+
 resource "google_dns_record_set" "cname-oci-cert-manager-io" {
   project      = module.cert-manager-general.project_id
   managed_zone = google_dns_managed_zone.cert-manager-io.name

--- a/gcp/modules/gcp-cluster/main.tf
+++ b/gcp/modules/gcp-cluster/main.tf
@@ -108,9 +108,13 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  gateway_api_config {
+    channel = var.cluster_enable_gateway_api ? "CHANNEL_STANDARD" : "CHANNEL_DISABLED"
+  }
+
   addons_config {
     http_load_balancing {
-      disabled = !var.cluster_enable_http_load_balancing
+      disabled = !var.cluster_enable_gateway_api
     }
 
     horizontal_pod_autoscaling {

--- a/gcp/modules/gcp-cluster/variables.tf
+++ b/gcp/modules/gcp-cluster/variables.tf
@@ -24,8 +24,8 @@ variable "cluster_enable_workload_identity" {
   type        = bool
   default     = false
 }
-variable "cluster_enable_http_load_balancing" {
-  description = "Whether to enable the HTTP load balancing addon"
+variable "cluster_enable_gateway_api" {
+  description = "Whether to enable the Gateway API on the GKE cluster"
   type        = bool
   default     = false
 }

--- a/gcp/trusted_prow_ip.tf
+++ b/gcp/trusted_prow_ip.tf
@@ -7,3 +7,13 @@ resource "google_compute_global_address" "prow_loadbalancer_ip" {
 
     address_type = "EXTERNAL"
 }
+
+# IP used by the prow Kubernetes Ingress to expose the Triage party UI.
+# This Ingress is annotated with the "kubernetes.io/ingress.global-static-ip-name: triage-infra-cert-manager-io"
+# annotation to use this static IP.
+resource "google_compute_global_address" "triage_loadbalancer_ip" {
+    project = module.cert-manager-tests-trusted.project_id
+    name = "triage-infra-cert-manager-io"
+
+    address_type = "EXTERNAL"
+}


### PR DESCRIPTION
depends on #54 

Adds infrastructure used by https://github.com/cert-manager/testing/pull/1038