### PR TITLE
Remove adam's old jetstack email

### DIFF
--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -5,7 +5,6 @@ locals {
     "user:mael.valais@jetstack.io",
     "user:richard.wall@jetstack.io",
     "user:ashley.davis@jetstack.io",
-    "user:adam.talbot@jetstack.io",
   ])
 
   gcp_region = "europe-west1"


### PR DESCRIPTION
This change was already made in the cloud, this PR just makes the terrform match what is already configured.

Adam's jetstack email is no longer used.