### PR TITLE
Use DNS endpoint for accessing kubernetes clusters

### DIFF
--- a/gcp/modules/gcp-cluster/main.tf
+++ b/gcp/modules/gcp-cluster/main.tf
@@ -74,6 +74,16 @@ resource "google_container_cluster" "cluster" {
     services_secondary_range_name = "services"
   }
 
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = true
+    }
+
+    ip_endpoints_config {
+      enabled = false
+    }
+  }
+
   logging_config {
     enable_components = [
       "SYSTEM_COMPONENTS",


### PR DESCRIPTION
- enables the DNS endpoint
- removes the IP control plane access