### PR TITLE
Use authoritive IAM to detect more config drift

### DIFF
--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -15,17 +15,20 @@ module "release-bucket" {
   location    = local.bucket_location
   bucket_name = "cert-manager-release"
 
-  bucket_viewers = local.cert_manager_release_managers
-  bucket_admins = [
-    # Grant the GCB service account admin permissions on objects in the bucket.
-    # This grants full control of objects, including listing, creating,
-    # viewing, and deleting objects.
-    # objectCreator is not sufficient, as the tool may need to delete or
-    # overwrite existing files.
-    # More information on roles can be found here:
-    # https://cloud.google.com/iam/docs/understanding-roles#storage-roles
-    local.cert_manager_release_gcb_service_account,
-  ]
+  bucket_viewers = []
+  bucket_admins = setunion(
+    local.cert_manager_release_managers,
+    [
+      # Grant the GCB service account admin permissions on objects in the bucket.
+      # This grants full control of objects, including listing, creating,
+      # viewing, and deleting objects.
+      # objectCreator is not sufficient, as the tool may need to delete or
+      # overwrite existing files.
+      # More information on roles can be found here:
+      # https://cloud.google.com/iam/docs/understanding-roles#storage-roles
+      local.cert_manager_release_gcb_service_account,
+    ],
+  )
 }
 
 module "trusted-artifacts-bucket" {
@@ -39,9 +42,10 @@ module "trusted-artifacts-bucket" {
   bucket_viewers = [
     "allUsers"
   ]
-  bucket_admins = [
-    google_service_account.prow-gcs-publisher.member
-  ]
+  bucket_admins = setunion(
+    local.cert_manager_release_managers,
+    [google_service_account.prow-gcs-publisher.member],
+  )
 }
 
 module "trusted-testgrid-bucket" {
@@ -51,15 +55,13 @@ module "trusted-testgrid-bucket" {
   location    = local.bucket_location
   bucket_name = "cert-manager-prow-testgrid"
 
-  bucket_viewers = setunion(
-    # Allow release managers to view TestGrid configs
-    local.cert_manager_release_managers,
-    [
-      "serviceAccount:testgrid-canary@k8s-testgrid.iam.gserviceaccount.com",
-      "serviceAccount:updater@k8s-testgrid.iam.gserviceaccount.com",
-    ],
-  )
-  bucket_admins = [
-    google_service_account.testgrid-updater.member
+  bucket_viewers = [
+    "serviceAccount:testgrid-canary@k8s-testgrid.iam.gserviceaccount.com",
+    "serviceAccount:updater@k8s-testgrid.iam.gserviceaccount.com",
   ]
+  bucket_admins = setunion(
+
+    local.cert_manager_release_managers,
+    [google_service_account.testgrid-updater.member],
+  )
 }

--- a/gcp/general_kubecon_booth.tf
+++ b/gcp/general_kubecon_booth.tf
@@ -86,7 +86,7 @@ resource "google_service_account" "booth_compute_sa" {
 resource "google_storage_bucket_iam_member" "bucket_access_policy" {
   bucket     = google_storage_bucket.cert_manager_booth_bucket.name
   role       = "roles/storage.admin"
-  member     = format("serviceAccount:%s", google_service_account.booth_compute_sa.email)
+  member     = google_service_account.booth_compute_sa.member
   depends_on = [google_storage_bucket.cert_manager_booth_bucket]
 }
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -5,7 +5,7 @@ terraform {
   }
 
   # backend "local" {
-  #  path = "terraform.tfstate"
+  #   path = "terraform.tfstate"
   # }
 
   required_version = ">= 1.6.1"

--- a/gcp/modules/gcp-bucket/main.tf
+++ b/gcp/modules/gcp-bucket/main.tf
@@ -20,18 +20,31 @@ resource "google_storage_bucket" "bucket" {
   versioning {
     enabled = var.bucket_versioned
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
-resource "google_storage_bucket_iam_binding" "object-viewers" {
-  bucket = google_storage_bucket.bucket.name
+data "google_iam_policy" "bucket" {
+  dynamic "binding" {
+    for_each = length(var.bucket_viewers) > 0 ? [1] : []
+    content {
+      role    = "roles/storage.objectViewer"
+      members = var.bucket_viewers
+    }
+  }
 
-  role    = "roles/storage.objectViewer"
-  members = var.bucket_viewers
+  dynamic "binding" {
+    for_each = length(var.bucket_admins) > 0 ? [1] : []
+    content {
+      role    = "roles/storage.objectAdmin"
+      members = var.bucket_admins
+    }
+  }
 }
 
-resource "google_storage_bucket_iam_binding" "object-admins" {
-  bucket = google_storage_bucket.bucket.name
-
-  role    = "roles/storage.objectAdmin"
-  members = var.bucket_admins
+resource "google_storage_bucket_iam_policy" "bucket" {
+  bucket      = google_storage_bucket.bucket.name
+  policy_data = data.google_iam_policy.bucket.policy_data
 }

--- a/gcp/modules/gcp-cluster/main.tf
+++ b/gcp/modules/gcp-cluster/main.tf
@@ -151,22 +151,6 @@ resource "google_service_account" "worker_pool_sa" {
   project      = var.project_id
 }
 
-resource "google_project_iam_binding" "worker_pool_sa_logWriter" {
-  project = var.project_id
-  role    = "roles/logging.logWriter"
-  members = [
-    google_service_account.worker_pool_sa.member
-  ]
-}
-
-resource "google_project_iam_binding" "worker_pool_sa_metricWriter" {
-  project = var.project_id
-  role    = "roles/monitoring.metricWriter"
-  members = [
-    google_service_account.worker_pool_sa.member
-  ]
-}
-
 resource "google_container_node_pool" "worker_pool" {
   name = "worker-pool-001"
 

--- a/gcp/modules/gcp-cluster/outputs.tf
+++ b/gcp/modules/gcp-cluster/outputs.tf
@@ -1,3 +1,7 @@
 output "workload_pool" {
   value = local.workload_pool
 }
+
+output "worker_pool_sa_member" {
+  value = google_service_account.worker_pool_sa.member
+}

--- a/gcp/modules/gcp-folder/main.tf
+++ b/gcp/modules/gcp-folder/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "7.33.0"
+    }
+  }
+  required_version = ">= 1.6.1"
+}
+
+resource "google_folder" "folder" {
+  display_name = var.folder_display_name
+  parent       = var.folder_parent
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+check "folder_id_match" {
+  assert {
+    condition     = google_folder.folder.folder_id == var.folder_id
+    error_message = "Folder ID mismatch: expected ${var.folder_id}, got ${google_folder.folder.folder_id}"
+  }
+}
+
+# Authoritative IAM policy for the folder
+data "google_iam_policy" "folder" {
+  dynamic "binding" {
+    for_each = var.folder_iam
+    content {
+      role    = binding.key
+      members = binding.value
+    }
+  }
+}
+
+resource "google_folder_iam_policy" "folder" {
+  folder      = google_folder.folder.name
+  policy_data = data.google_iam_policy.folder.policy_data
+}

--- a/gcp/modules/gcp-folder/outputs.tf
+++ b/gcp/modules/gcp-folder/outputs.tf
@@ -1,0 +1,14 @@
+output "folder_id" {
+  description = "The folder ID (numeric)"
+  value       = google_folder.folder.folder_id
+}
+
+output "name" {
+  description = "The full resource name (folders/FOLDER_ID)"
+  value       = google_folder.folder.name
+}
+
+output "display_name" {
+  description = "The display name of the folder"
+  value       = google_folder.folder.display_name
+}

--- a/gcp/modules/gcp-folder/variables.tf
+++ b/gcp/modules/gcp-folder/variables.tf
@@ -1,0 +1,20 @@
+variable "folder_id" {
+  description = "The folder ID (numeric)"
+  type        = string
+}
+
+variable "folder_display_name" {
+  description = "The display name of the folder"
+  type        = string
+}
+
+variable "folder_parent" {
+  description = "The parent resource (organizations/ORG_ID or folders/FOLDER_ID)"
+  type        = string
+}
+
+variable "folder_iam" {
+  description = "Authoritative IAM bindings for the folder. Map of role -> list of members."
+  type        = map(list(string))
+  default     = {}
+}

--- a/gcp/modules/gcp-project/main.tf
+++ b/gcp/modules/gcp-project/main.tf
@@ -8,6 +8,87 @@ terraform {
   required_version = ">= 1.6.1"
 }
 
+locals {
+  # see https://docs.cloud.google.com/iam/docs/service-agents
+  # Since we authoritatively manage the project's IAM, we also need to include any roles required
+  # by Google-managed service accounts for enabled APIs.
+  service_agent_roles = {
+    "artifactregistry.googleapis.com" = {
+      "roles/artifactregistry.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
+      ]
+    },
+    "logging.googleapis.com" = {
+      "roles/logging.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-logging.iam.gserviceaccount.com",
+      ]
+    },
+    "bigquerydatatransfer.googleapis.com" = {
+      "roles/bigquerydatatransfer.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com",
+      ]
+    },
+    "compute.googleapis.com" = {
+      "roles/compute.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@compute-system.iam.gserviceaccount.com",
+      ]
+    },
+    "container.googleapis.com" = {
+      "roles/container.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com",
+      ]
+      "roles/container.defaultNodeServiceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-gkenode.iam.gserviceaccount.com",
+      ]
+      "roles/gkehub.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-gkehub.iam.gserviceaccount.com",
+      ]
+    },
+    "cloudbuild.googleapis.com" = {
+      "roles/cloudbuild.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com",
+      ]
+    },
+    "cloudkms.googleapis.com" = {
+      "roles/cloudkms.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-cloudkms.iam.gserviceaccount.com",
+      ]
+    },
+    "pubsub.googleapis.com" = {
+      "roles/pubsub.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com",
+      ]
+    },
+    "cloudscheduler.googleapis.com" = {
+      "roles/cloudscheduler.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com",
+      ]
+    },
+    "cloudfunctions.googleapis.com" = {
+      "roles/cloudfunctions.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
+      ]
+    },
+    "cloudasset.googleapis.com" = {
+      "roles/cloudasset.serviceAgent" = [
+        "serviceAccount:service-${google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com",
+      ]
+    },
+    // TODO: Add more roles when we enable/ use more APIs.
+    "iamcredentials.googleapis.com" = {},
+    "storage.googleapis.com"        = {},
+    "dns.googleapis.com"            = {},
+  }
+
+  # Default service accounts that GCP creates automatically for all projects
+  # We need to include them since we're using an authoritative IAM policy
+  default_service_accounts = {
+    "roles/editor" = [
+      "serviceAccount:${google_project.project.number}@cloudservices.gserviceaccount.com",
+    ]
+  }
+}
+
 resource "google_project" "project" {
   name            = var.project_name
   project_id      = var.project_id
@@ -17,24 +98,20 @@ resource "google_project" "project" {
   auto_create_network = false
 
   lifecycle {
-    prevent_destroy = "true"
+    prevent_destroy = true
   }
 }
 
-# Lien to prevent manual deletion https://cloud.google.com/resource-manager/docs/project-liens 
+# Lien to prevent manual deletion https://cloud.google.com/resource-manager/docs/project-liens
 resource "google_resource_manager_lien" "block_deletion" {
   parent       = "projects/${google_project.project.number}"
   restrictions = ["resourcemanager.projects.delete"]
   origin       = "${var.project_id}-project-lien"
   reason       = "This project is an important environment"
-}
 
-# Add all cert-manager release managers as 'owners' of the GCP project.
-resource "google_project_iam_member" "project_owners" {
-  for_each = var.project_owners
-  project  = google_project.project.project_id
-  role     = "roles/owner"
-  member   = each.value
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Enable all required APIs for the project.
@@ -43,7 +120,58 @@ resource "google_project_service" "project_apis" {
   project  = google_project.project.project_id
   service  = each.value
 
-  # If this service is disabled (i.e. the Terraform resource is destroyed),
-  # automatically disable any dependent project services.
-  disable_dependent_services = true
+  # Generate an error if any enabled services depend on this service when destroying it.
+  disable_dependent_services = false
+
+  # Don't actually disable the service when the resource is destroyed.
+  # This prevents accidental service disruption when removing from Terraform.
+  disable_on_destroy = false
+}
+
+# Merge all IAM bindings, combining members for duplicate roles
+locals {
+  # Collect all role bindings from different sources
+  all_role_bindings = concat(
+    [for api in var.project_apis : local.service_agent_roles[api]],
+    [var.project_iam],
+    [local.default_service_accounts]
+  )
+
+  # Merge bindings, combining member lists for the same role
+  merged_iam = {
+    for role in distinct(flatten([for binding_map in local.all_role_bindings : keys(binding_map)])) :
+    role => distinct(flatten([
+      for binding_map in local.all_role_bindings :
+      lookup(binding_map, role, [])
+    ]))
+  }
+}
+
+# Authoritative IAM policy for the project
+data "google_iam_policy" "project" {
+  dynamic "binding" {
+    for_each = local.merged_iam
+    content {
+      role    = binding.key
+      members = binding.value
+    }
+  }
+
+  dynamic "audit_config" {
+    for_each = var.audit_configs
+    content {
+      service = audit_config.value.service
+      dynamic "audit_log_configs" {
+        for_each = audit_config.value.log_types
+        content {
+          log_type = audit_log_configs.value
+        }
+      }
+    }
+  }
+}
+
+resource "google_project_iam_policy" "project" {
+  project     = google_project.project.project_id
+  policy_data = data.google_iam_policy.project.policy_data
 }

--- a/gcp/modules/gcp-project/variables.tf
+++ b/gcp/modules/gcp-project/variables.tf
@@ -14,12 +14,20 @@ variable "project_billing_id" {
   description = "The billing account to associate with the project"
   type        = string
 }
-variable "project_owners" {
+variable "project_apis" {
   type    = set(string)
   default = []
 }
-
-variable "project_apis" {
-  type    = set(string)
+variable "project_iam" {
+  description = "Authoritative IAM bindings for the project. Map of role -> list of members."
+  type        = map(list(string))
+  default     = {}
+}
+variable "audit_configs" {
+  description = "Audit log configurations for the project."
+  type = list(object({
+    service   = string
+    log_types = list(string)
+  }))
   default = []
 }

--- a/gcp/projects.tf
+++ b/gcp/projects.tf
@@ -1,6 +1,17 @@
 locals {
-  project_folder_id       = "585046353847"         # cert-manager folder
   cncf_project_billing_id = "010256-CB82C2-8ED6FC" # "CNCF Invoiced Billing"
+}
+
+module "cert-manager-folder" {
+  source = "./modules/gcp-folder/"
+
+  folder_display_name = "cert-manager"
+  folder_id           = "585046353847"               # cert-manager folder
+  folder_parent       = "organizations/782639440630" # CNCF organization
+  folder_iam = {
+    "roles/resourcemanager.folderAdmin"  = setunion(local.cert_manager_release_managers, ["user:hahmadzai@linuxfoundation.org"])
+    "roles/resourcemanager.folderEditor" = ["user:hahmadzai@linuxfoundation.org"],
+  }
 }
 
 module "cert-manager-general" {
@@ -8,12 +19,26 @@ module "cert-manager-general" {
 
   project_name       = "CM generic project"
   project_id         = "cert-manager-general"
-  project_folder_id  = local.project_folder_id
+  project_folder_id  = module.cert-manager-folder.folder_id
   project_billing_id = local.cncf_project_billing_id
-  project_owners     = local.cert_manager_release_managers
   project_apis = toset([
-    "dns.googleapis.com"
+    "dns.googleapis.com",
+    "compute.googleapis.com",
+    "pubsub.googleapis.com",
+    "storage.googleapis.com",
   ])
+  project_iam = {
+    "roles/owner"                               = local.cert_manager_release_managers
+    "roles/resourcemanager.projectOwnerInvitee" = local.cert_manager_release_managers_invitee
+    "roles/storage.admin" = setunion(
+      local.cert_manager_release_managers,
+      [google_service_account.booth_compute_sa.member]
+    )
+    "roles/dns.admin" = [
+      # TODO: this service account should be mananaged by terraform
+      "serviceAccount:dns01-solver@cert-manager-general.iam.gserviceaccount.com",
+    ]
+  }
 }
 
 module "cert-manager-release" {
@@ -21,14 +46,34 @@ module "cert-manager-release" {
 
   project_name       = "CM release infra"
   project_id         = "cert-manager-release"
-  project_folder_id  = local.project_folder_id
+  project_folder_id  = module.cert-manager-folder.folder_id
   project_billing_id = local.cncf_project_billing_id
-  project_owners     = local.cert_manager_release_managers
   project_apis = toset([
     "cloudbuild.googleapis.com",
-    "storage.googleapis.com",
     "cloudkms.googleapis.com",
+    "compute.googleapis.com",
+    "storage.googleapis.com",
   ])
+  audit_configs = [
+    {
+      service   = "cloudkms.googleapis.com"
+      log_types = ["ADMIN_READ", "DATA_READ", "DATA_WRITE"]
+    },
+  ]
+  project_iam = {
+    "roles/owner"                               = local.cert_manager_release_managers
+    "roles/resourcemanager.projectOwnerInvitee" = local.cert_manager_release_managers_invitee
+    "roles/storage.admin"                       = local.cert_manager_release_managers
+    # Allow release managers access to all required APIs for interacting with
+    # the Cloud Build service.
+    # https://cloud.google.com/iam/docs/understanding-roles#cloud-build-roles
+    # We must explicitly grant the managed GCP service account IAM permission
+    # to launch jobs in the project because this role is authoritatively managed.
+    "roles/cloudbuild.builds.builder" = setunion(
+      local.cert_manager_release_managers,
+      [local.cert_manager_release_gcb_service_account],
+    )
+  }
 }
 
 module "cert-manager-tests-trusted" {
@@ -36,14 +81,25 @@ module "cert-manager-tests-trusted" {
 
   project_name       = "CM testing infra - trusted"
   project_id         = "cert-manager-tests-trusted"
-  project_folder_id  = local.project_folder_id
+  project_folder_id  = module.cert-manager-folder.folder_id
   project_billing_id = local.cncf_project_billing_id
-  project_owners     = local.cert_manager_release_managers
   project_apis = toset([
     "compute.googleapis.com",
     "container.googleapis.com",
+    "pubsub.googleapis.com",
     "artifactregistry.googleapis.com",
+    "storage.googleapis.com",
   ])
+  project_iam = {
+    "roles/owner"                               = local.cert_manager_release_managers
+    "roles/resourcemanager.projectOwnerInvitee" = local.cert_manager_release_managers_invitee
+    "roles/storage.admin"                       = local.cert_manager_release_managers
+    "roles/logging.logWriter"                   = [module.prow-cluster-trusted.worker_pool_sa_member]
+    "roles/monitoring.metricWriter"             = [module.prow-cluster-trusted.worker_pool_sa_member]
+    (google_project_iam_custom_role.prow-gencred-custom-role["cert-manager-tests-trusted"].name) = [
+      google_service_account.prow-gencred.member,
+    ]
+  }
 }
 
 module "cert-manager-tests-untrusted" {
@@ -51,11 +107,20 @@ module "cert-manager-tests-untrusted" {
 
   project_name       = "CM testing infra - untrusted"
   project_id         = "cert-manager-tests-untrusted"
-  project_folder_id  = local.project_folder_id
+  project_folder_id  = module.cert-manager-folder.folder_id
   project_billing_id = local.cncf_project_billing_id
-  project_owners     = local.cert_manager_release_managers
   project_apis = toset([
     "compute.googleapis.com",
     "container.googleapis.com",
+    "pubsub.googleapis.com",
   ])
+  project_iam = {
+    "roles/owner"                               = local.cert_manager_release_managers
+    "roles/resourcemanager.projectOwnerInvitee" = local.cert_manager_release_managers_invitee
+    "roles/logging.logWriter"                   = [module.prow-cluster-untrusted.worker_pool_sa_member]
+    "roles/monitoring.metricWriter"             = [module.prow-cluster-untrusted.worker_pool_sa_member]
+    (google_project_iam_custom_role.prow-gencred-custom-role["cert-manager-tests-untrusted"].name) = [
+      google_service_account.prow-gencred.member,
+    ]
+  }
 }

--- a/gcp/release.tf
+++ b/gcp/release.tf
@@ -3,33 +3,6 @@ locals {
   cert_manager_release_gcb_service_account = format("serviceAccount:%s@cloudbuild.gserviceaccount.com", module.cert-manager-release.number)
 }
 
-resource "google_service_account" "scheduler_gcb_invoker" {
-  account_id   = "scheduler-gcb-invoker"
-  description  = "Allows cloud-scheduler to invoke GCB jobs"
-  display_name = "scheduler-gcb-invoker"
-  project      = module.cert-manager-release.project_id
-}
-
-resource "google_project_iam_binding" "cert-manager-release_managers" {
-  project = module.cert-manager-release.project_id
-  role    = "roles/cloudbuild.builds.builder"
-
-  members = setunion(
-    # Allow release managers access to all required APIs for interacting with
-    # the Cloud Build service.
-    # More information on this role can be found here:
-    # https://cloud.google.com/iam/docs/understanding-roles#cloud-build-roles
-    local.cert_manager_release_managers,
-    # We must explicitly grant the managed GCP service account IAM permission
-    # to launch jobs in the project because the 'iam_binding' type of Terraform
-    # resource is authorative for the role type.
-    [
-      local.cert_manager_release_gcb_service_account,
-      google_service_account.scheduler_gcb_invoker.member,
-    ],
-  )
-}
-
 #####
 ## Define Cloud KMS keyring and related IAM permissions
 #####

--- a/gcp/trusted_gke_access.tf
+++ b/gcp/trusted_gke_access.tf
@@ -43,11 +43,3 @@ resource "google_project_iam_custom_role" "prow-gencred-custom-role" {
   ]
 }
 
-resource "google_project_iam_binding" "prow-gencred-rolebinding" {
-  for_each = google_project_iam_custom_role.prow-gencred-custom-role
-
-  project = each.key
-
-  role    = each.value.name
-  members = [google_service_account.prow-gencred.member]
-}

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -10,6 +10,9 @@ locals {
     "user:ashley.davis@jetstack.io",
     "user:ashdavis@paloaltonetworks.com",
   ])
+  cert_manager_release_managers_invitee = toset([
+    "user:riwall@paloaltonetworks.com",
+  ])
 
   gcp_region = "europe-west1"
 


### PR DESCRIPTION
This pull request makes significant improvements to the management of GCP project and folder IAM policies, moving from imperative, ad-hoc IAM bindings to a more declarative and authoritative approach using `google_project_iam_policy` and `google_folder_iam_policy`. It also introduces a reusable folder module, centralizes IAM role bindings, and updates bucket and service account permissions for greater clarity and maintainability.

The most important changes are:

**Authoritative IAM Policy Management:**
* Replaces individual `google_project_iam_member` and `google_project_iam_binding` resources with a single authoritative `google_project_iam_policy` for each project, merging all required IAM bindings, service agent roles, and audit configs into a single policy. This ensures consistent and predictable IAM state across all projects. [[1]](diffhunk://#diff-a6c5988adc855cb9d26d80b704383e5bd64149559bddf95580401de7ef4e9bffL46-R176) [[2]](diffhunk://#diff-4e1e8d8e30a80a5e389ef9ee18c5637af3434f02246b22665819fc51215b3c27L17-R31) [[3]](diffhunk://#diff-d81d98815db738d2633f7d53c91c4efb20046b50a9c34bd809bd56d742b1b075L2-R125)
* Adds a new reusable `gcp-folder` module that creates GCP folders with an authoritative IAM policy via `google_folder_iam_policy`, and integrates this into project creation. [[1]](diffhunk://#diff-97c6962e5a63779fb1f64778ae70bd4d6b47038c15b1119bfedb5a2f06b0fb0cR1-R41) [[2]](diffhunk://#diff-cfcc917265f907760e789df1b1cef288ae2dd7c29b0a28c5d58249662d62b089R1-R20) [[3]](diffhunk://#diff-7a62667f30e3b64496836640f8e686608668ff57335b371ebbf2928e52cb54f7R1-R14) [[4]](diffhunk://#diff-d81d98815db738d2633f7d53c91c4efb20046b50a9c34bd809bd56d742b1b075L2-R125)

**Bucket and Service Account Permissions:**
* Refactors bucket IAM bindings to use `google_storage_bucket_iam_policy` with dynamic role bindings, and ensures that release managers are consistently included as admins where appropriate. Viewer and admin assignments are clarified and centralized. [[1]](diffhunk://#diff-3c5683e070e35d87ed1544e314d5237f2788304b8826ccc2d7e092c1609ec9f6L18-R21) [[2]](diffhunk://#diff-3c5683e070e35d87ed1544e314d5237f2788304b8826ccc2d7e092c1609ec9f6L42-R48) [[3]](diffhunk://#diff-3c5683e070e35d87ed1544e314d5237f2788304b8826ccc2d7e092c1609ec9f6L54-R66) [[4]](diffhunk://#diff-6ad4a4685a2571aceb4f4a8c7c7a94b99d389b38340af0b0b97b4b87ba332560L23-R50)
* Updates service account member references to use the `.member` attribute for consistency and correctness.

**Project Structure and Inputs:**
* Refactors project modules to accept `project_iam` and `audit_configs` variables for centralized IAM and audit logging configuration, and removes the now-unnecessary `project_owners` variable. [[1]](diffhunk://#diff-4e1e8d8e30a80a5e389ef9ee18c5637af3434f02246b22665819fc51215b3c27L17-R31) [[2]](diffhunk://#diff-d81d98815db738d2633f7d53c91c4efb20046b50a9c34bd809bd56d742b1b075L2-R125)

**Cleanup of Redundant Resources:**
* Removes redundant or now-unmanaged IAM bindings for service accounts, worker pools, and custom roles, since these are now handled by the authoritative project IAM policy. [[1]](diffhunk://#diff-e83dbff29d90316a4e0d1a50d3f95b74b1e793e16aeead4aed87ac741d345af2L154-L169) [[2]](diffhunk://#diff-8f9066e2510676a1e499ef6c3a493af54461d07447ade899b193d6467d870b3fL46-L53) [[3]](diffhunk://#diff-cbef618e5f5b48fa4398c3ae3d25a6f601d954ced4f2dd21423b4ccfe69fda42L6-L32)

**Service Agent Role Management:**
* Automatically includes required Google-managed service agent roles for enabled APIs to prevent accidental removal of essential permissions when managing IAM policies authoritatively.

These changes modernize and standardize GCP resource management, making IAM more predictable, maintainable, and less error-prone.