### PR TITLE
Replace deprecated gcb service account

### DIFF
--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -26,7 +26,7 @@ module "release-bucket" {
       # overwrite existing files.
       # More information on roles can be found here:
       # https://cloud.google.com/iam/docs/understanding-roles#storage-roles
-      local.cert_manager_release_gcb_service_account,
+      google_service_account.cert-manager-release-gcb.member,
     ],
   )
 }
@@ -60,7 +60,6 @@ module "trusted-testgrid-bucket" {
     "serviceAccount:updater@k8s-testgrid.iam.gserviceaccount.com",
   ]
   bucket_admins = setunion(
-
     local.cert_manager_release_managers,
     [google_service_account.testgrid-updater.member],
   )

--- a/gcp/projects.tf
+++ b/gcp/projects.tf
@@ -67,11 +67,11 @@ module "cert-manager-release" {
     # Allow release managers access to all required APIs for interacting with
     # the Cloud Build service.
     # https://cloud.google.com/iam/docs/understanding-roles#cloud-build-roles
-    # We must explicitly grant the managed GCP service account IAM permission
-    # to launch jobs in the project because this role is authoritatively managed.
+    # We must explicitly grant the user-managed Cloud Build service account
+    # permission to launch jobs because this role binding is authoritative.
     "roles/cloudbuild.builds.builder" = setunion(
       local.cert_manager_release_managers,
-      [local.cert_manager_release_gcb_service_account],
+      [google_service_account.cert-manager-release-gcb.member],
     )
   }
 }

--- a/gcp/release.tf
+++ b/gcp/release.tf
@@ -1,6 +1,8 @@
-locals {
-  // The service account used by Cloud Build (see https://console.cloud.google.com/cloud-build/settings/service-account?project=cert-manager-release).
-  cert_manager_release_gcb_service_account = format("serviceAccount:%s@cloudbuild.gserviceaccount.com", module.cert-manager-release.number)
+// Custom service account used by Cloud Build for cert-manager release jobs.
+resource "google_service_account" "cert-manager-release-gcb" {
+  project      = module.cert-manager-release.project_id
+  account_id   = "cert-manager-release-gcb"
+  display_name = "Cloud Build SA for cert-manager release jobs"
 }
 
 #####
@@ -47,7 +49,7 @@ resource "google_kms_crypto_key_iam_binding" "cert-manager-release_secret-key-de
   # Grant the Cloud Build service account permission to decrypt secrets using
   # the secret key.
   members = [
-    local.cert_manager_release_gcb_service_account,
+    google_service_account.cert-manager-release-gcb.member,
   ]
 }
 
@@ -85,6 +87,6 @@ resource "google_kms_crypto_key_iam_binding" "cert-manager-release_signing-key-s
 
   # Signing should be done only by cmrel in cloudbuild jobs
   members = [
-    local.cert_manager_release_gcb_service_account,
+    google_service_account.cert-manager-release-gcb.member,
   ]
 }

--- a/gcp/release_gcb.tf
+++ b/gcp/release_gcb.tf
@@ -1,10 +1,11 @@
 resource "google_cloudbuild_trigger" "cert-manager-build-on-tag" {
   description = "Builds cert-manager when a tag is pushed"
 
-  filename = "gcb/build_cert_manager.yaml"
-  location = "global"
-  name     = "cert-manager-build-on-tag"
-  project  = module.cert-manager-release.project_id
+  filename        = "gcb/build_cert_manager.yaml"
+  location        = "global"
+  name            = "cert-manager-build-on-tag"
+  project         = module.cert-manager-release.project_id
+  service_account = google_service_account.cert-manager-release-gcb.id
 
   approval_config {
     approval_required = false


### PR DESCRIPTION
Replace deprecated gcb service account with custom created service account: https://docs.cloud.google.com/build/docs/cloud-build-service-account