### PR TITLE
Connect to k8s using DNS endpoint

### DIFF
--- a/gcp/modules/gcp-cluster/main.tf
+++ b/gcp/modules/gcp-cluster/main.tf
@@ -112,6 +112,15 @@ resource "google_container_cluster" "cluster" {
     channel = var.cluster_enable_gateway_api ? "CHANNEL_STANDARD" : "CHANNEL_DISABLED"
   }
 
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = true
+    }
+    ip_endpoints_config {
+      enabled = false
+    }
+  }
+
   addons_config {
     http_load_balancing {
       disabled = !var.cluster_enable_gateway_api


### PR DESCRIPTION
Connect to testing k8s endpoints using DNS instead of static IP (see https://cloud.google.com/blog/products/containers-kubernetes/new-dns-based-endpoint-for-the-gke-control-plane).
This is now possible thanks to us replacing the gencred tool.

Linked to this testing PR: https://github.com/cert-manager/testing/pull/1185