### PR TITLE
Switch image builder to workload identity

### DIFF
--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -47,6 +47,7 @@ module "trusted-artifacts-bucket" {
     google_service_account.prowjob-default-trusted.member,
     google_service_account.prowjob-default-untrusted.member,
     google_service_account.testgrid-updater.member,
+    google_service_account.image-builder.member,
   ]
   bucket_admins = local.cert_manager_release_managers
 }

--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -43,7 +43,9 @@ module "trusted-artifacts-bucket" {
   bucket_writers = [
     # The crier application needs access to the bucket
     google_service_account.prow-control-plane["crier"].member,
-    # Let prow jobs push their logs to the bucket (both default prow job service accounts and the testgrid updater service account)
+    # Let prow jobs push their logs to the bucket
+    # By default prow jobs use the prowjob-default service account, but some
+    # jobs use a custom service account, so we need to grant access to both.
     google_service_account.prowjob-default-trusted.member,
     google_service_account.prowjob-default-untrusted.member,
     google_service_account.testgrid-updater.member,

--- a/gcp/test_pods_service_accounts.tf
+++ b/gcp/test_pods_service_accounts.tf
@@ -10,6 +10,9 @@
 #   it via Config Merger
 #   (https://github.com/GoogleCloudPlatform/testgrid/tree/master/cmd/config_merge).
 #   See https://github.com/kubernetes/test-infra/blob/master/testgrid/merging.md
+# - image-builder: used by image-building postsubmit ProwJobs to push container
+#   images to the cert-manager-infra-images Artifact Registry without a static
+#   service account key.
 
 resource "google_service_account" "prowjob-default-trusted" {
   account_id   = "prowjob-default"
@@ -50,5 +53,19 @@ resource "google_service_account_iam_binding" "testgrid-updater-workload-identit
   role               = "roles/iam.workloadIdentityUser"
   members = [
     "serviceAccount:${module.prow-cluster-trusted.workload_pool}[test-pods/testgrid-updater]"
+  ]
+}
+
+resource "google_service_account" "image-builder" {
+  account_id   = "image-builder"
+  display_name = "Service account for image-building ProwJobs that push to Artifact Registry"
+  project      = module.cert-manager-tests-trusted.project_id
+}
+
+resource "google_service_account_iam_binding" "image-builder-workload-identity" {
+  service_account_id = google_service_account.image-builder.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "serviceAccount:${module.prow-cluster-trusted.workload_pool}[test-pods/image-builder]"
   ]
 }

--- a/gcp/trusted_artifact_registry.tf
+++ b/gcp/trusted_artifact_registry.tf
@@ -20,19 +20,11 @@ resource "google_artifact_registry_repository_iam_member" "cert-manager-infra-im
   member     = "allUsers"
 }
 
-# service account that will be used to publish the docker images to the artifact registry
-resource "google_service_account" "cert-manager-infra-images-publisher" {
-  project = module.cert-manager-tests-trusted.project_id
-
-  account_id   = "prow-infra-images-publisher"
-  display_name = "Service account that allows Prow to publish docker images to the artifact registry"
-}
-
 resource "google_artifact_registry_repository_iam_member" "cert-manager-infra-images-writer" {
   project  = module.cert-manager-tests-trusted.project_id
   location = local.artifact_location
 
   repository = google_artifact_registry_repository.cert-manager-infra-images.name
   role       = "roles/artifactregistry.writer"
-  member     = google_service_account.cert-manager-infra-images-publisher.member
+  member     = google_service_account.image-builder.member
 }


### PR DESCRIPTION
Linked to https://github.com/cert-manager/testing/pull/1188, contains infrastructure changes required for that PR.