### PR TITLE
Make sure GitHub tags can trigger jobs

### DIFF
--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/hashicorp/google" {
   constraints = "7.33.0"
   hashes = [
     "h1:ShrlDeVxFw1rwM7y/NxIY0V3Xt5Ktw7fkfPPli+b1q0=",
+    "h1:kXuu7ka7LqoA5z/V0fMDp+pstdGln8ZwURaw7l6HmLQ=",
     "zh:07de05a3d2fc5e431b57afd0160f20a878d41ac6118ae3a9789574744d32ff68",
     "zh:28f1f0b90c34d1d8b410a3060a6b5eccde9118ed591d675f358c889e53555436",
     "zh:368a32cfc61109545570f9e8fae45b73f067293afbab86f9fe7ddead5a6de99f",

--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -29,6 +29,18 @@ module "release-bucket" {
   bucket_admins = local.cert_manager_release_managers
 }
 
+module "release-logs-bucket" {
+  source = "./modules/gcp-bucket/"
+
+  project_id  = module.cert-manager-release.project_id
+  location    = local.bucket_location
+  bucket_name = "cert-manager-release-logs"
+  bucket_admins = setunion(
+    local.cert_manager_release_managers,
+    [google_service_account.cert-manager-release-gcb.member],
+  )
+}
+
 module "trusted-artifacts-bucket" {
   source = "./modules/gcp-bucket/"
 

--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -35,10 +35,12 @@ module "release-logs-bucket" {
   project_id  = module.cert-manager-release.project_id
   location    = local.bucket_location
   bucket_name = "cert-manager-release-logs"
-  bucket_admins = setunion(
-    local.cert_manager_release_managers,
-    [google_service_account.cert-manager-release-gcb.member],
-  )
+
+  # Cloud Builds needs roles/storage.admin. The role roles/storage.objectAdmin,
+  # which you get with bucket_admins, isn't enough. See:
+  # https://docs.cloud.google.com/build/docs/securing-builds/store-manage-build-logs#store-custom-bucket
+  admins        = [google_service_account.cert-manager-release-gcb.member]
+  bucket_admins = local.cert_manager_release_managers
 }
 
 module "trusted-artifacts-bucket" {

--- a/gcp/clusters.tf
+++ b/gcp/clusters.tf
@@ -17,6 +17,9 @@ module "prow-cluster-trusted" {
     machine_type = "n1-standard-2"
     disk_size_gb = "25"
     disk_type    = "pd-ssd"
+
+    # We want to make the nodes more reliable; maintainers were saying they were
+    # experiencing Prow issues.
     preemptible  = false
   }
 }
@@ -39,6 +42,6 @@ module "prow-cluster-untrusted" {
     machine_type = "e2-highcpu-16"
     disk_size_gb = "150"
     disk_type    = "pd-ssd"
-    preemptible  = true
+    preemptible  = false
   }
 }

--- a/gcp/modules/gcp-bucket/.terraform.lock.hcl
+++ b/gcp/modules/gcp-bucket/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "7.33.0"
+  constraints = "7.33.0"
+  hashes = [
+    "h1:kXuu7ka7LqoA5z/V0fMDp+pstdGln8ZwURaw7l6HmLQ=",
+    "zh:07de05a3d2fc5e431b57afd0160f20a878d41ac6118ae3a9789574744d32ff68",
+    "zh:28f1f0b90c34d1d8b410a3060a6b5eccde9118ed591d675f358c889e53555436",
+    "zh:368a32cfc61109545570f9e8fae45b73f067293afbab86f9fe7ddead5a6de99f",
+    "zh:3b2b46f4c0a0158af0c8d0d60940d03607a42a38935fd5d894c8dc7800b34158",
+    "zh:444e709ebe6185321e204acc8332c4f7ca064714f79492be9216be8092c099c4",
+    "zh:640f8631bb6adfe8245877800c0f7fa92180640ee6437ef6c0e9db91dd21317a",
+    "zh:6da9aca693acf82618f4f81efb90fcde7a0108140e99c61e8e27e1fbe14a5692",
+    "zh:931a49fb84699d0ac0048005a8adb07e7683add23c18a224cf53ad6a2c057cab",
+    "zh:9fb1aa4ad0e6e7353564b0be599a1f11da82377d490b9621a71e9af3e77ed326",
+    "zh:a834ad5fa8b1cb3e9a75ab4480edd7676c4d96806e38c3d550ae29854edaae4f",
+    "zh:b7d0a29c6c759fed2f7174e959721cbc69db0da4e21c286714ff8aa4fb959b0a",
+    "zh:cf6e8c300d64badd66260e40d9ba1712c25513fb8b4233687d2cc3381f9a903c",
+    "zh:d217567a762995a56f314145f218dfa0bc0e290bdea52249d68c760ad7293f2e",
+    "zh:ea2a468f760f4086c4789152cdb186f54269960ac5b8a0103901af81f0584522",
+    "zh:ef27b779c08c033ab8ad205642247aaf11ed5e46196ee48840318499395eef13",
+  ]
+}

--- a/gcp/modules/gcp-bucket/main.tf
+++ b/gcp/modules/gcp-bucket/main.tf
@@ -50,6 +50,14 @@ data "google_iam_policy" "bucket" {
       members = var.bucket_admins
     }
   }
+
+  dynamic "binding" {
+    for_each = length(var.admins) > 0 ? [1] : []
+    content {
+      role    = "roles/storage.admin"
+      members = var.admins
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_policy" "bucket" {

--- a/gcp/modules/gcp-bucket/variables.tf
+++ b/gcp/modules/gcp-bucket/variables.tf
@@ -33,3 +33,7 @@ variable "bucket_admins" {
   type    = set(string)
   default = []
 }
+variable "admins" {
+  type    = set(string)
+  default = []
+}

--- a/gcp/projects.tf
+++ b/gcp/projects.tf
@@ -62,15 +62,19 @@ module "cert-manager-release" {
   project_iam = {
     "roles/owner"         = local.cert_manager_release_managers
     "roles/storage.admin" = local.cert_manager_release_managers
-    # Allow release managers access to all required APIs for interacting with
-    # the Cloud Build service.
-    # https://cloud.google.com/iam/docs/understanding-roles#cloud-build-roles
-    # We must explicitly grant the user-managed Cloud Build service account
-    # permission to launch jobs because this role binding is authoritative.
-    "roles/cloudbuild.builds.builder" = setunion(
-      local.cert_manager_release_managers,
-      [google_service_account.cert-manager-release-gcb.member],
-    )
+
+    "roles/cloudbuild.builds.editor" = [
+      # When clicking "Run" in the UI or when running `gcloud builds triggers
+      # run`, the legacy Cloud Build SA is still used to trigger the run (because we have
+      # these 3 Organization policies: constraints/cloudbuild.disableCreateDefaultServiceAccount,
+      # constraints/cloudbuild.useComputeServiceAccount and constraints/cloudbuild.useBuildServiceAccount,
+      # see https://docs.cloud.google.com/build/docs/cloud-build-service-account-updates#configure_the_default_service_account_for_an_organization for more info).
+      # So we need to grant it roles/cloudbuild.builds.editor.
+      "serviceAccount:${module.cert-manager-release.number}@cloudbuild.gserviceaccount.com",
+    ]
+    "roles/logging.logWriter" = [
+      google_service_account.cert-manager-release-gcb.member,
+    ]
   }
 }
 

--- a/gcp/projects.tf
+++ b/gcp/projects.tf
@@ -72,9 +72,10 @@ module "cert-manager-release" {
       # So we need to grant it roles/cloudbuild.builds.editor.
       "serviceAccount:${module.cert-manager-release.number}@cloudbuild.gserviceaccount.com",
     ]
-    "roles/logging.logWriter" = [
-      google_service_account.cert-manager-release-gcb.member,
-    ]
+
+    # Due to configs.logging=CLOUD_LOGGING_ONLY in cert-manager's
+    # gcb/build_cert_manager.yaml.
+    "roles/logging.logWriter" = [google_service_account.cert-manager-release-gcb.member]
   }
 }
 

--- a/gcp/release.tf
+++ b/gcp/release.tf
@@ -83,3 +83,11 @@ resource "google_kms_crypto_key_iam_binding" "cert-manager-release_signing-key-s
   # Signing should be done only by cmrel in cloudbuild jobs
   members = [google_service_account.cert-manager-release-gcb.member]
 }
+
+# The signing process also needs to read key metadata (cloudkms.cryptoKeys.get)
+# to fetch the default hash function. signerVerifier doesn't include this permission.
+resource "google_kms_crypto_key_iam_binding" "cert-manager-release_signing-key-viewers" {
+  crypto_key_id = google_kms_crypto_key.cert-manager-release_signing-key.id
+  role          = "roles/cloudkms.viewer"
+  members       = [google_service_account.cert-manager-release-gcb.member]
+}

--- a/gcp/release.tf
+++ b/gcp/release.tf
@@ -40,17 +40,12 @@ resource "google_kms_crypto_key_iam_binding" "cert-manager-release_secret-key-en
   members = local.cert_manager_release_managers
 }
 
-# Define list of users with cryptoKeyDecrypter permissions on the release
-# secret key.
+# The Cloud Build user-specified service account needs permission to decrypt the
+# release secret key.
 resource "google_kms_crypto_key_iam_binding" "cert-manager-release_secret-key-decrypters" {
   crypto_key_id = google_kms_crypto_key.cert-manager-release_secret-key.id
   role          = "roles/cloudkms.cryptoKeyDecrypter"
-
-  # Grant the Cloud Build service account permission to decrypt secrets using
-  # the secret key.
-  members = [
-    google_service_account.cert-manager-release-gcb.member,
-  ]
+  members       = [google_service_account.cert-manager-release-gcb.member]
 }
 
 # Key for signing cert-manager release artifacts
@@ -76,7 +71,7 @@ resource "google_kms_crypto_key" "cert-manager-release_signing-key" {
 
 # Define list of users who have permission to sign using this key.
 resource "google_kms_crypto_key_iam_binding" "cert-manager-release_signing-key-signers" {
-  crypto_key_id = google_kms_crypto_key.cert-manager-release_secret-key.id
+  crypto_key_id = google_kms_crypto_key.cert-manager-release_signing-key.id
 
   # https://cloud.google.com/kms/docs/reference/permissions-and-roles
   # "roles/cloudkms.signer" doesn't include permission to get the public key, which is required
@@ -86,7 +81,5 @@ resource "google_kms_crypto_key_iam_binding" "cert-manager-release_signing-key-s
   role = "roles/cloudkms.signerVerifier"
 
   # Signing should be done only by cmrel in cloudbuild jobs
-  members = [
-    google_service_account.cert-manager-release-gcb.member,
-  ]
+  members = [google_service_account.cert-manager-release-gcb.member]
 }


### PR DESCRIPTION
**Companion PR of:**
- https://github.com/cert-manager/cert-manager/pull/8851
- https://github.com/cert-manager/release/pull/310
- https://github.com/cert-manager/cert-manager/pull/8857

I've pushed v1.21.0-alpha.1 this morning, but no GCB job was triggered. I can't see anything in Google Cloud Logs either that would suggest a problem. My assumption was that there was some permission issue somewhere and the github-triggered jobs wouldn't get created. But no error can be seen in Google Cloud Logs...

For context, two weeks ago, we switched from using the default GCB service account to a custom service account in https://github.com/cert-manager/infrastructure/pull/74.

When triggering a build with "Run" in the UI, I was getting:

```
Failed to trigger build: Permission 'cloudbuild.builds.create' denied on resource 'projects/000000edccbb9785' (or it may not exist)
```

I came across https://stackoverflow.com/questions/79508588/cloud-build-trigger-fails-with-permission-denied-permission-cloudbuild-builds. The person came across the same weird `0000`-prefixed project number... So I granted the "Cloud Build Service Account" role to `1021342095237@cloudbuild.gserviceaccount.com` (= the default GCB service account) to see. I was now able to trigger a job with "Run".

I've read the docs in https://docs.cloud.google.com/build/docs/cloud-build-service-account at least 100 times, and I still can't make sense of it. Here is a snippet:

> User access to triggers [...] for **user-specified service account**: Any user with the Cloud Build Editor role who has the `iam.serviceAccounts.actAs` permission can create and directly run a trigger. For example, a user can run the trigger manually.
>
> Note: If you use the same service account to trigger and run a build, then that service account must still have the `iam.serviceAccount.actAs` (included in the roles/iam.serviceAccountUser role) permission.

Makes no sense to me. What I've observed instead is the following:

1. When clicking "Run" or running `gcloud builds triggers run`, 1021342095237@cloudbuild.gserviceaccount.com (legacy Cloud Build SA) is used to trigger the run.
2. When pushing a tag, service-1021342095237@gcp-sa-cloudbuild.iam.gserviceaccount.com (Cloud Build service agent SA) is used.

Note that in both cases, the build will be running using the least-priviledged cert-manager-release-gcb@cert-manager-release.iam.gserviceaccount.com SA.

---

## Trigger builds and Legacy Cloud Build service account

We have learned that the Trigger feature in Cloud Builds never uses the authenticated user as the identity that creates the builds. It always uses a fixed service account. As explained in [Cloud Build default service account change](https://docs.cloud.google.com/build/docs/cloud-build-service-account-updates#configure_the_default_service_account_for_an_organization), there are three possible "trigger" service accounts:

- The legacy Cloud Build service account (that's what we are using)
- The default Compute Build service account
- The user-specified service account selected in the Trigger.

In our case, we are forced to use the legacy Cloud Build service account before of the following policies:

| Policy (= constraint) | Value |
|--|--|
| disableCreateDefaultServiceAccount | true  |
| useComputeServiceAccount (= use the new default Compute SA) | true |
| useBuildServiceAccount (= use the legacy Cloud Build SA)  | true |

Since we are on an old project (pre-2024), `useComputeServiceAccount` doesn't do anything since `disableCreateDefaultServiceAccount` prevents the creation of the default Compute service account. This is why the legacy Cloud Build service account is used for creating the builds on tag push + `gcloud builds triggers run` + click on "Run" in the UI. We can see which SA is used to trigger with:

```bash
$ gcloud builds get-default-service-account
1021342095237@cloudbuild.gserviceaccount.com
```

## Trigger build vs. Execute build

The SA 1021342095237@cloudbuild.gserviceaccount.com only needs to be able to create builds, not execute them. 

On the other hand, cert-manager-release-gcb@cert-manager-release.iam.gserviceaccount.com is the SA used to execute the build. We only give it the permission to write the logs as well as some other things like read the KMS public key.