### PR TITLE
Enable cluster_enable_workload_identity by default

### DIFF
--- a/gcp/clusters.tf
+++ b/gcp/clusters.tf
@@ -7,7 +7,6 @@ module "prow-cluster-trusted" {
   cluster_name        = "prow-trusted"
   cluster_description = "Test cluster for trusted tests"
 
-  cluster_enable_workload_identity = true
   cluster_enable_gateway_api       = true
 
   node_config = {
@@ -32,8 +31,6 @@ module "prow-cluster-untrusted" {
   location            = local.gke_zonal_location
   cluster_name        = "prow-untrusted"
   cluster_description = "Test cluster for untrusted tests"
-
-  cluster_enable_workload_identity = true
 
   node_config = {
     min_count = 0

--- a/gcp/modules/gcp-cluster/main.tf
+++ b/gcp/modules/gcp-cluster/main.tf
@@ -8,6 +8,10 @@ terraform {
   required_version = ">= 1.6.1"
 }
 
+locals {
+  workload_pool = "${var.project_id}.svc.id.goog"
+}
+
 resource "google_compute_network" "network" {
   name        = "k8s-${var.cluster_name}-network"
   description = "Network for the ${var.cluster_name} GKE cluster"
@@ -139,11 +143,8 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  dynamic "workload_identity_config" {
-    for_each = local.workload_pool != null ? [1] : []
-    content {
-      workload_pool = local.workload_pool
-    }
+  workload_identity_config {
+    workload_pool = local.workload_pool
   }
 
   lifecycle {
@@ -198,11 +199,8 @@ resource "google_container_node_pool" "worker_pool" {
       "https://www.googleapis.com/auth/cloud-platform"
     ]
 
-    dynamic "workload_metadata_config" {
-      for_each = var.cluster_enable_workload_identity ? [1] : []
-      content {
-        mode = "GKE_METADATA"
-      }
+    workload_metadata_config {
+      mode = "GKE_METADATA"
     }
   }
 

--- a/gcp/modules/gcp-cluster/variables.tf
+++ b/gcp/modules/gcp-cluster/variables.tf
@@ -19,11 +19,6 @@ variable "cluster_description" {
   description = "The description of the GKE cluster"
   type        = string
 }
-variable "cluster_enable_workload_identity" {
-  description = "Whether to attach a workload pool to all Kubernetes service accounts"
-  type        = bool
-  default     = false
-}
 variable "cluster_enable_gateway_api" {
   description = "Whether to enable the Gateway API on the GKE cluster"
   type        = bool
@@ -40,8 +35,4 @@ variable "node_config" {
     disk_type    = string
     preemptible  = bool
   })
-}
-
-locals {
-  workload_pool = var.cluster_enable_workload_identity ? "${var.project_id}.svc.id.goog" : null
 }


### PR DESCRIPTION
Make `cluster_enable_workload_identity` non-optional