### PR TITLE
Enable shielded nodes

### DIFF
--- a/gcp/modules/gcp-cluster/main.tf
+++ b/gcp/modules/gcp-cluster/main.tf
@@ -49,7 +49,7 @@ resource "google_container_cluster" "cluster" {
   project  = var.project_id
   location = var.location
 
-  enable_shielded_nodes = false
+  enable_shielded_nodes = true
   enable_legacy_abac    = false
 
   # We can't create a cluster with no node pool defined, but we want to only use


### PR DESCRIPTION
Improves the security of our prow clusters: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes